### PR TITLE
Use sbatch --exclusive

### DIFF
--- a/odybcl2fastq/Snakefile
+++ b/odybcl2fastq/Snakefile
@@ -88,7 +88,7 @@ rule demultiplex_10x_cmd:
         cmd+="mkdir -p {config[output_slurm]}{wildcards.run}/fastq\n"
         cmd+="mkdir -p /scratch/{wildcards.run}_fastq_\$SLURM_JOB_ID\n"
         cmd+="cd /scratch/{wildcards.run}_fastq_\$SLURM_JOB_ID\n"
-        cmd+="cellranger{config[atac]} mkfastq $dual_index --run={config[source_slurm]}{wildcards.run} --samplesheet={config[source_slurm]}{wildcards.run}/SampleSheet.csv --output-dir=/scratch/{wildcards.run}_fastq_\$SLURM_JOB_ID --localmem=\$((SLURM_MEM_PER_NODE/1000)) --localcores=\$SLURM_JOB_CPUS_PER_NODE || exit_code=\$?\n"
+        cmd+="cellranger{config[atac]} mkfastq $dual_index --run={config[source_slurm]}{wildcards.run} --samplesheet={config[source_slurm]}{wildcards.run}/SampleSheet.csv --output-dir=/scratch/{wildcards.run}_fastq_\$SLURM_JOB_ID --localmem=\$((9*\$(ulimit -m)/10000)) --loading-threads=\$((SLURM_JOB_CPUS_PER_NODE/4)) --writing-threads=\$((SLURM_JOB_CPUS_PER_NODE/4)) --processing-threads=\${SLURM_JOB_CPUS_PER_NODE} --localcores=\$SLURM_JOB_CPUS_PER_NODE || exit_code=\$?\n"
         cmd+="rsync -rtl --safe-links --perms --chmod=Dug=rwx,Fug=rw /scratch/{wildcards.run}_fastq_\$SLURM_JOB_ID/ {config[output_slurm]}{wildcards.run}/fastq/ || exit_code=\$((exit_code + \$?))\n"
         cmd+="rm -rf /scratch/{wildcards.run}_fastq_\$SLURM_JOB_ID\n"
         cmd+="exit \$exit_code"
@@ -131,7 +131,7 @@ rule count_10x_cmd:
         cmd+="mkdir -p {config[output_slurm]}{wildcards.run}/count\n"
         cmd+="mkdir -p /scratch/{wildcards.run}_{wildcards.sample}_\$SLURM_JOB_ID\n"
         cmd+="cd /scratch/{wildcards.run}_{wildcards.sample}_\$SLURM_JOB_ID\n"
-        cmd+="cellranger{config[atac]} count --id={wildcards.sample} $transcriptome --sample={wildcards.sample} --fastqs=$fastq_path --localmem=\$((SLURM_MEM_PER_NODE/1000)) --localcores=\$SLURM_JOB_CPUS_PER_NODE || exit_code=\$?\n\n"
+        cmd+="cellranger{config[atac]} count --id={wildcards.sample} $transcriptome --sample={wildcards.sample} --fastqs=$fastq_path --localmem=\$((9*\$(ulimit -m)/10000)) --localcores=\$SLURM_JOB_CPUS_PER_NODE || exit_code=\$?\n\n"
         cmd+="rsync -rtl --safe-links --perms --chmod=Dug=rwx,Fug=rw /scratch/{wildcards.run}_{wildcards.sample}_\$SLURM_JOB_ID/{wildcards.sample}/ {config[output_slurm]}{wildcards.run}/count/{wildcards.sample}/ || exit_code=\$((exit_code + \$?))\n"
         cmd+="rm -rf /scratch/{wildcards.run}_{wildcards.sample}_\$SLURM_JOB_ID\n"
         cmd+="exit \$exit_code"
@@ -184,7 +184,7 @@ rule fastqc_cmd:
         cmd="#!/bin/bash\n"
         cmd+="ulimit -u \$(ulimit -Hu)\n"
         cmd+="mkdir -p {config[output_slurm]}{wildcards.run}/QC\n"
-        cmd+="fastqc -o {config[output_slurm]}{wildcards.run}/QC --threads 1 $(find {config[output_slurm]}{wildcards.run}/fastq/ -name *.fastq.gz -not -name Undetermined* -print0 | xargs -0)"
+        cmd+="fastqc -o {config[output_slurm]}{wildcards.run}/QC --threads \${SLURM_JOB_CPUS_PER_NODE} $(find {config[output_slurm]}{wildcards.run}/fastq/ -name *.fastq.gz -not -name Undetermined* -print0 | xargs -0)"
         echo "$cmd" >> {output}
         chmod 777 {output}
         """

--- a/odybcl2fastq/slurm_submit.py
+++ b/odybcl2fastq/slurm_submit.py
@@ -50,8 +50,8 @@ os.remove((job_props['input'][0] + 'test'))
 with open(job_props['input'][0], 'r') as fh:
     cmd = fh.readlines()
 
-prefix = []
-cli_opts = []
+prefix = ["#SBATCH --exclusive\n"]
+cli_opts = ["--exclusive"]
 # get slurm opts as a prefix for cmd
 for prop, val in slurm_opts.items():
     if prop in job_props['cluster']:

--- a/odybcl2fastq/snakemake_cluster.json
+++ b/odybcl2fastq/snakemake_cluster.json
@@ -2,27 +2,20 @@
     "__default__": {
         "time": "0:00:10",
         "N": 1,
-        "cores": 8,
-        "mem": 100,
+        "mem": 0,
         "partition": "bos-info_priority",
         "name": "{rule}.{wildcards.run}",
         "out": "{config[output_slurm]}{wildcards.run}/log/{rule}-%j.out",
         "error": "{config[output_slurm]}{wildcards.run}/log/{rule}-%j.err"
     },
     "demultiplex_10x": {
-        "time": "4-20:00:00",
-        "cores": 12,
-        "mem": 32000
+        "time": "4-20:00:00"
     },
     "fastqc": {
-        "time": "4-12:00:00",
-        "cores": 8,
-        "mem": 32000
+        "time": "4-12:00:00"
     },
     "count_10x": {
         "time": "4-18:00:00",
-        "cores": 12,
-        "mem": 90000,
         "name": "{rule}.{wildcards.run}_{wildcards.sample}",
         "out": "{config[output_slurm]}{wildcards.run}/log/{rule}.{wildcards.sample}-%j.out",
         "error": "{config[output_slurm]}{wildcards.run}/log/{rule}.{wildcards.sample}-%j.err"


### PR DESCRIPTION
Reduce likelihood of exhausting local scratch space, and reduce runtime of an individual stage to limit impact of system failure.

For cellranger, set --localmem==90% of allocated memory to avoid errors reported when free memory is exhausted