### PR TITLE
Lower priority of cellranger count jobs

### DIFF
--- a/odybcl2fastq/slurm_submit.py
+++ b/odybcl2fastq/slurm_submit.py
@@ -25,6 +25,7 @@ slurm_opts = OrderedDict([
         ('time', '-t'),
         ('mem', '--mem'),
         ('name', '-J'),
+        ('nice', '--nice'),
         ('out', '-o'),
         ('error', '-e'),
         ('x', '-x')

--- a/odybcl2fastq/snakemake_cluster.json
+++ b/odybcl2fastq/snakemake_cluster.json
@@ -16,6 +16,7 @@
     },
     "count_10x": {
         "time": "4-18:00:00",
+        "nice": "100",
         "name": "{rule}.{wildcards.run}_{wildcards.sample}",
         "out": "{config[output_slurm]}{wildcards.run}/log/{rule}.{wildcards.sample}-%j.out",
         "error": "{config[output_slurm]}{wildcards.run}/log/{rule}.{wildcards.sample}-%j.err"


### PR DESCRIPTION
Prioritize demultiplexing / fastqc jobs by de-prioritizing count jobs via `sbatch --nice`.