### PR TITLE
allow for 10x restart

### DIFF
--- a/odybcl2fastq/Snakefile
+++ b/odybcl2fastq/Snakefile
@@ -69,6 +69,8 @@ rule insert_run_into_bauer_db:
         analysis_file_path = '%s%s/%s/analysis_id' % (ody_config.SOURCE_DIR, wildcards.run, STATUS_DIR)
         with open(analysis_file_path, 'w+') as f:
             f.write(str(analysis_id))
+        # for a new analysis remove the script dir to ensure a total restart
+        shell("rm {output}{run}/script/*", output={ody_config.OUTPUT_DIR}, run=config['run'])
 
 rule demultiplex_10x_cmd:
     """


### PR DESCRIPTION
Since we no longer have the martian pipeline files copying over then restarting is less of a problem, the only change I needed to make is to delete the contents of the script directory so that scripts will be recreated incase anything like reference library might have changed. 

With this change once status dir is deleted the run should be picked back up by the pipeline and rerun overwriting previous results.  We may want to allow giving a suffix rather than overwriting as we do with the non 10x pipeline but I thought I might take that on when I bring non 10x into snakemake. 