### PR TITLE
Fix SampleSheet AttributeError

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # odybcl2fastq
-A python packages wrapping Illumina's bcl2fastq software to demultiplex HiSeq and NextSeq runs, for use on the Odyssey cluster. The end goal of this package is to automate demultiplexing of sequencing runs, and generate QC metrics and reports for end users that will aid in interpreting the quality of the resulting sequence data. Odybcl2fastq is being developed using the Anaconda 1.9.2 distribution of python (v. 2.7.11).
+A python packages wrapping Illumina's bcl2fastq software to demultiplex HiSeq and NextSeq runs, for use on the Odyssey cluster. The end goal of this package is to automate demultiplexing of sequencing runs, and generate QC metrics and reports for end users that will aid in interpreting the quality of the resulting sequence data.
 ## Getting Started
 
 Clone this git repository.  Set up an anaconda environment with python 2.7.11. Install the dependencies.

--- a/odybcl2fastq/parsers/samplesheet.py
+++ b/odybcl2fastq/parsers/samplesheet.py
@@ -264,6 +264,13 @@ class SampleSheet(object):
                 projects.append(row['Sample_Project'])
         return projects
 
+    def get_samples(self):
+        samples = []
+        for key, row in self.sections['Data'].items():
+            if row['Sample_ID']:
+                samples.append(row['Sample_ID'])
+        return samples
+
     def has_poly_A_index(self):
         for k, row in self.sections['Data'].items():
             if 'AAAA' in row['index']:

--- a/odybcl2fastq/parsers/samplesheet.py
+++ b/odybcl2fastq/parsers/samplesheet.py
@@ -130,7 +130,7 @@ class SampleSheet(object):
 
     def validate_index2(self):
         corrected = False
-        fixed = self.samples
+        fixed = self.get_samples()
         if 'index2' in fixed.columns:
             if fixed[fixed.index2!=''].empty:
                 # we have a totally empty index2 column so delete

--- a/odybcl2fastq/parsers/samplesheet.py
+++ b/odybcl2fastq/parsers/samplesheet.py
@@ -130,17 +130,13 @@ class SampleSheet(object):
 
     def validate_index2(self):
         corrected = False
-        fixed = self.get_samples()
-        if 'index2' in fixed.columns:
-            if fixed[fixed.index2!=''].empty:
-                # we have a totally empty index2 column so delete
-                fixed = fixed.drop('index2', axis = 1)
-                if 'I5_index_ID' in fixed.columns:
-                    fixed = fixed.drop('I5_index_ID', axis = 1)
-                corrected = True
-                fixed_rows = fixed.to_dict('records')
-                for i, k in enumerate(self.sections['Data'].keys()):
-                    self.sections['Data'][k] = OrderedDict(fixed_rows[i])
+        if len(self.sections['Data']) == sum(('index2','') in sample.items() for sample in self.sections['Data'].values()):
+            # we have a totally empty index2 column so delete
+            corrected = True
+            for sample in self.sections['Data']:
+                del self.sections['Data'][sample]['index2']
+                if 'I5_index_ID' in self.sections['Data'][sample]:
+                    del self.sections['Data'][sample]['I5_index_ID']
         return corrected
 
     def validate_sample_names(self):
@@ -267,13 +263,6 @@ class SampleSheet(object):
             if row['Sample_Project']:
                 projects.append(row['Sample_Project'])
         return projects
-
-    def get_samples(self):
-        samples = []
-        for key, row in self.sections['Data'].items():
-            if row['Sample_ID']:
-                samples.append(row['Sample_ID'])
-        return samples
 
     def has_poly_A_index(self):
         for k, row in self.sections['Data'].items():


### PR DESCRIPTION
SampleSheet.samples attribute [no longer exists](https://github.com/harvardinformatics/odybcl2fastq/commit/edadf1658d1fa48f35e32b767568fb6d71586d92#diff-305d6b25521c7845f3bf2e16cc88d70bL14), resulting in the AttributeError:
```
'SampleSheet' object has no attribute 'samples'
Traceback (most recent call last):
  File "odybcl2fastq/process_snakemake_runs.py", line 418, in main
    process_runs(pool)
  File "odybcl2fastq/process_snakemake_runs.py", line 357, in process_runs
    opts = get_ody_snakemake_opts(run_dir, ss_path, run_type, suffix, mask_suffix)
  File "odybcl2fastq/process_snakemake_runs.py", line 222, in get_ody_snakemake_opts
    sample_sheet.validate()
  File "/app/odybcl2fastq/parsers/samplesheet.py", line 123, in validate
    if self.validate_sample_names() | self.validate_index2():
  File "/app/odybcl2fastq/parsers/samplesheet.py", line 133, in validate_index2
    fixed = self.samples
```

Since the former _samples_ attribute was constructed from the _sections_ attribute by get_samples(), and is only referenced (and not updated) at that point in the code, removing it would seem to make sense; its sole reference could be replaced by a call to get_samples().